### PR TITLE
Restructure introduction of booleans and boolean logic

### DIFF
--- a/Basics.ipynb
+++ b/Basics.ipynb
@@ -300,10 +300,11 @@
    "cell_type": "markdown",
    "id": "ddb77cb8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Demonstration of using _Jupyter_ notebook"
@@ -313,23 +314,14 @@
    "cell_type": "markdown",
    "id": "6be1345f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "Jupyter works with cells such as these, which you execute with the play button or `Shift/Ctrl + Enter`:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9d12ce9",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -341,7 +333,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -350,22 +343,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a8f48be",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "12764b89",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "If the box on the left is empty, you have not executed it. Otherwise a number indicates in which order the execution took place.\n",
@@ -416,10 +400,11 @@
    "cell_type": "markdown",
    "id": "c515267a",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Basic data types\n",
@@ -488,22 +473,16 @@
    "cell_type": "markdown",
    "id": "98edd5e0",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "The `print` function which outputs text or variable values to the screen so they are visible while the program runs.\n",
     "\n",
     "This is one way to allow you to see what your program is doing as it executes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dace0de0",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -515,23 +494,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# print statement \"Hello\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3ea6bf5e",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -543,23 +511,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# put the content of the print statement in a variable\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1d6afc5",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -571,21 +528,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# check the type of that variable\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7512901d",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
    ]
   },
   {
@@ -617,23 +565,14 @@
    "cell_type": "markdown",
    "id": "610b7c33",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Add integers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bdba3aca",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -645,23 +584,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding two integers (2 and 5)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e38b2a6f",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -673,23 +601,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding integers to a string (\"2+5 = \") naively\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6cf46063",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -701,7 +618,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -710,35 +628,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1401fd54",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "99bc4e26",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Boolean type"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ab9ccbc",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -750,23 +649,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# boolean have to be capitalized\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f9c2fa7",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -778,23 +666,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Checking the type of a boolean\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8f7263f3",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -806,23 +683,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding a boolean to an integer\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1a0d4827",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -834,154 +700,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Checking the type of the result\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f2b76987",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "396617ca",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    },
-    "editable": false
-   },
-   "source": [
-    "### _<ins>Example</ins>:_ Boolean operators"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2162f785",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02a0ed98",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Adding booleans\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bf01971",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8fe2a9fa",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Logical AND\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8485e6f8",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a3cd6635",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Logical OR\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c028c985",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "646ecc5a",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Negating boolean\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce8e6377",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
    ]
   },
   {
@@ -1124,10 +848,11 @@
    "cell_type": "markdown",
    "id": "264f4cf3",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "You could try\n",
@@ -1143,23 +868,14 @@
    "cell_type": "markdown",
    "id": "bf4d52bb",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "31296375",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1171,7 +887,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1180,35 +897,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1241418e",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4757c3c2",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1cfa3f7e",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1220,7 +918,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1229,22 +928,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc0685df",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "6bf1c0b8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "True is converted to one and False is converted to zero"
@@ -1254,23 +944,14 @@
    "cell_type": "markdown",
    "id": "3060c201",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "39136b9e",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1282,7 +963,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1291,35 +973,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "494572b1",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "8ffe919b",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d3bb0cdf",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1331,7 +994,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1340,22 +1004,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6acfd6a8",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ca7a2bf1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### _Example solutions_\n",
@@ -1366,23 +1021,14 @@
    "cell_type": "markdown",
    "id": "5280e49d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "##### 1. Syntax Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "505b62e1",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1394,42 +1040,24 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "4101da3d",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1786772f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "##### 2. Semantic Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e925ba8",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1441,42 +1069,24 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "689fbc03",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "5234c07e",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "##### 3. Runtime Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "80174eef",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1488,29 +1098,21 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "3abfff6f",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "2f3d5124",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Interlude: Indented blocks in python\n",
@@ -1594,10 +1196,11 @@
    "cell_type": "markdown",
    "id": "6bd208c9",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _Exercises_\n",
@@ -1605,9 +1208,7 @@
     "**1)** Write a function that converts Celsius to Fahrenheit. Use the formula  \n",
     "$\n",
     "\\text{Fahrenheit} = (\\text{Celsius} \\times \\frac{9}{5}) + 32\n",
-    "$\n",
-    "\n",
-    "<!-- #solution -->"
+    "$"
    ]
   },
   {
@@ -1616,29 +1217,24 @@
    "id": "a4b09ae2",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "9ca4bf11",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "698e44f7",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>**Part II**</ins>"
@@ -1980,10 +1576,11 @@
    "cell_type": "markdown",
    "id": "99ce3685",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "* A list contains items separated by commas and enclosed with square brackets `[]`\n",
@@ -1996,15 +1593,14 @@
    "cell_type": "markdown",
    "id": "a7d14dc3",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
-    "### _<ins>Examples:</ins>_\n",
-    "\n",
-    "<!-- #solution -->"
+    "### _<ins>Examples:</ins>_"
    ]
   },
   {
@@ -2025,18 +1621,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "027f913a",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b7cbcdd2",
@@ -2054,18 +1638,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "00c19747",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2bec453c",
@@ -2074,23 +1646,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print an element of the list. Note: use [] not () for item indexing\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce970cc8",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2102,23 +1663,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print the first element of the list. Indexing starts with 0!\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7e5c8937",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2130,23 +1680,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print the last element of the list using backward indexing\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19332ca8",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2158,23 +1697,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print an internal slice of the list\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c0194d5b",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2186,23 +1714,12 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print a slice of the list from the beginning\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b687058f",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2211,23 +1728,15 @@
    "id": "ca455b93",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Different datatypes in lists, length of lists\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "826d0594",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2236,23 +1745,15 @@
    "id": "86f486b3",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print out `list1`, a slice containing the last element\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd364758",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2261,21 +1762,15 @@
    "id": "0aa952b1",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Concatenate two lists\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "63c23a98",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
    ]
   },
   {
@@ -2415,12 +1910,14 @@
    "cell_type": "markdown",
    "id": "82edf40e",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "**1) Lists**: Create a list of numbers from 1 to 20 and then print the elements at every second index.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**1) Lists**: Create a list of numbers from 1 to 20 and then print the elements at every second index."
    ]
   },
   {
@@ -2429,42 +1926,27 @@
    "id": "bd25dc80",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "a5201641",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "958677ed",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "**2) Range**: Create a list of even numbers between 10 and 30 using `range()`, and print it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f15c5ea7",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2476,7 +1958,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
@@ -2485,10 +1968,11 @@
    "cell_type": "markdown",
    "id": "5efb8831",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>5.</ins> Conditional and control flow statements"
@@ -2496,12 +1980,374 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24d65380",
+   "id": "b70dd974-edaf-4754-9584-93f50921e743",
    "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Comparisons and Logical Operators\n",
+    "Before we can make decisions in our code, we need to be able to compare values. Python provides several comparison operators that evaluate to boolean values (`True` or `False`). Comparison operators always return a boolean value (`True` or `False`). These are essential for making decisions in your code:\n",
+    "* `>` greater than\n",
+    "* `<` less than\n",
+    "* `==` equal to (note: two equals signs!)\n",
+    "* `!=` not equal to\n",
+    "* `>=` greater than or equal to\n",
+    "* `<=` less than or equal to\n",
+    "\n",
+    "Logical operators combine boolean values:\n",
+    "\n",
+    "* `and`: Returns `True` only if both conditions are `True`\n",
+    "* `or`: Returns `True` if at least one condition is `True`\n",
+    "* `not`: Inverts the boolean value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32e96a87-2d10-4fde-9d13-c3e805753b12",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da74c8ad-9e71-41b2-8dd0-8e3ec967678b",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "These operators become crucial when writing more complex conditions in `if`-statements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74af5f47-ab75-4df1-91b8-3190bedc2ca6",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### _<ins>Examples:</ins>_ Comparisons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2cceb3d-3087-4a36-97de-e2e812c591e4",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Basic comparisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0b84d51-59ca-4825-9246-a2a9577a2c30",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x = 5\n",
+    "y = 10\n",
+    "\n",
+    "print(x > y)   # Greater than: False\n",
+    "print(x < y)   # Less than: True\n",
+    "print(x == y)  # Equal to: False\n",
+    "print(x != y)  # Not equal to: True\n",
+    "print(x >= 5)  # Greater than or equal: True\n",
+    "print(x <= 10) # Less than or equal: True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c907d157-f6a7-4b69-8f6e-93c1ff5fc94e",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Comparisons with strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e71c33a-f7dc-41f7-b440-dd5b3b1694b4",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "name1 = \"Alice\"\n",
+    "name2 = \"Bob\"\n",
+    "\n",
+    "print(name1 == name2)  # False\n",
+    "print(name1 != name2)  # True\n",
+    "# Strings can be compared alphabetically\n",
+    "print(name1 < name2)   # True (A comes before B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fed5023-5d86-4427-96b0-555924659ed1",
+   "metadata": {
+    "editable": false
+   },
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6452908a-8d20-43c3-a515-8a524a526d9d",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Common mistake:** Using `=` (assignment) instead of `==` (comparison)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "396617ca",
+   "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
+   },
+   "source": [
+    "### _<ins>Examples</ins>:_ Logical operators"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89b36ecb-cdca-403c-956a-fb3a76fd020d",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Now that we can create boolean values through comparisons, we can combine them using logical operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02a0ed98",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Adding booleans\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fe2a9fa",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Logical AND\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3cd6635",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Logical OR\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "646ecc5a",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Negating boolean\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "980d102d-ab45-4277-a5cc-1a87da38a217",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Combining comparisons\n",
+    "age = 25\n",
+    "has_license = True\n",
+    "\n",
+    "# Using AND - both conditions must be True\n",
+    "can_drive = age >= 18 and has_license\n",
+    "print(f\"Can drive: {can_drive}\")  # True\n",
+    "\n",
+    "# Using OR - at least one condition must be True\n",
+    "temperature = 35\n",
+    "is_hot = temperature > 30 or temperature < 0\n",
+    "print(f\"Extreme temperature: {is_hot}\")  # True\n",
+    "\n",
+    "# Using NOT - inverts the boolean value\n",
+    "is_minor = not (age >= 18)\n",
+    "print(f\"Is minor: {is_minor}\")  # False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6e41b34-6325-41d8-ac88-d12f6a4a0b4f",
+   "metadata": {
+    "editable": false,
+    "jp-MarkdownHeadingCollapsed": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### <ins>_Exercises_</ins>:\n",
+    "\n",
+    "You could try:\n",
+    " - **comparing different data types** - what happens when you compare a string with a number?\n",
+    " - **chaining comparisons** - try expressions like `1 < x < 10`\n",
+    " - **combining multiple conditions** - use `and`, `or`, and `not` together\n",
+    " - what happens if you mix numbers and bools in arithmetic expressions?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a50a84-306d-45dd-a1f4-28fe86b67360",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### <ins>_Bridge Exercise</ins>:_ Temperature Checker\n",
+    "Write code that checks if a temperature is comfortable (between 18\u00b0C and 25\u00b0C):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "795e6224-3e3f-40ad-ac82-0c677f48ed1d",
+   "metadata": {
+    "editable": true,
+    "remove_code": "all",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fabcdd8-baea-43bd-b61e-7af35de49381",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "This exercise demonstrates how comparison and logical operators work together - exactly what you'll use in `if`-statements next!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24d65380",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
    },
    "source": [
     "## _If_-statements"
@@ -2511,10 +2357,18 @@
    "cell_type": "markdown",
    "id": "86caca1c",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
-    "An `if`-statement evaluates a condition (an expression that returns `True` or `False`) and executes a block of code if the condition is true. Python uses conditional operators, colons `:` and indentation to define blocks of code. The `elif` (else if) statement allows checking multiple conditions sequentially. Once a condition evaluates to `True`, the rest are ignored. If no conditions are true, you can use an `else` statement as a fallback."
+    "An `if`-statement evaluates a condition (an expression that returns `True` or `False`) and executes a block of code if the condition is true.\n",
+    "\n",
+    "**Remember:** We create these conditions using the comparison operators (`>`, `<`, `==`, `!=`, `>=`, `<=`) and logical operators (`and`, `or`, `not`) that we've just learned.\n",
+    "\n",
+    "Python uses conditional operators, colons `:` and indentation to define blocks of code. The `elif` (else if) statement allows checking multiple conditions sequentially. Once a condition evaluates to `True`, the rest are ignored. If no conditions are true, you can use an `else` statement as a fallback."
    ]
   },
   {
@@ -2558,7 +2412,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "02da94e1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "x = 10\n",
@@ -2580,7 +2440,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b3cfe09f",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# using only `if`\n",
@@ -2600,7 +2466,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c3505308",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# using `if`, `elif` and `else`\n",
@@ -2688,7 +2560,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2e7d84a5",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "my_list = [\"Andrew\", \"John\", \"Kate\"]\n",
@@ -2760,7 +2638,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "078c8e13",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "count = 0\n",
@@ -2773,7 +2657,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21d1a0d2",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "n=1\n",
@@ -2804,10 +2694,11 @@
    "cell_type": "markdown",
    "id": "7a2f1f84",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _Exercises_"
@@ -2817,23 +2708,14 @@
    "cell_type": "markdown",
    "id": "c60fe3a1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "**1) `If`-statements**: Write a program that asks for a user's age and prints whether the person is a minor, an adult, or a senior citizen."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f9dfcb0",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2842,7 +2724,11 @@
    "id": "263767ef",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
@@ -2851,17 +2737,14 @@
    "cell_type": "markdown",
    "id": "1cfae422",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**2) `For`-loops**: Use a `for`-loop to print the square of numbers from 1 to 10.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**2) `For`-loops**: Use a `for`-loop to print the square of numbers from 1 to 10."
    ]
   },
   {
@@ -2870,7 +2753,11 @@
    "id": "2f67bcec",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
@@ -2879,17 +2766,14 @@
    "cell_type": "markdown",
    "id": "87c1529d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**3) `While`-loops**: Write a program that keeps asking the user for a number and prints the number. Stop when the user enters a negative number.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**3) `While`-loops**: Write a program that keeps asking the user for a number and prints the number. Stop when the user enters a negative number."
    ]
   },
   {
@@ -2898,7 +2782,11 @@
    "id": "7d063a72",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
@@ -2907,17 +2795,14 @@
    "cell_type": "markdown",
    "id": "db69b6c7",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**4) Functions**: Write a program to calculate the factorial of a number\n",
-    "\n",
-    "<!-- #solution -->"
+    "**4) Functions**: Write a program to calculate the factorial of a number"
    ]
   },
   {
@@ -2926,7 +2811,11 @@
    "id": "7827b090",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": []
@@ -3318,7 +3207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/Basics.ipynb
+++ b/Basics.ipynb
@@ -2273,23 +2273,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02a0ed98",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Adding booleans\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "8fe2a9fa",
    "metadata": {
     "editable": true,
@@ -2336,6 +2319,37 @@
    "outputs": [],
    "source": [
     "# Negating boolean\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02a0ed98",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Adding booleans\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "918b8f36-0c33-43e5-830b-8036021b822f",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "editable": false
+   },
+   "source": [
+    "### Combining comparisons\n",
+    "Logical operators are commonly used to combine comparisons"
    ]
   },
   {
@@ -3397,7 +3411,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/Basics.ipynb
+++ b/Basics.ipynb
@@ -4,10 +4,11 @@
    "cell_type": "markdown",
    "id": "2d68459e",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "ARC course \"Learning to programme with Python\" (beginner level)\n",
@@ -19,10 +20,11 @@
    "cell_type": "markdown",
    "id": "fdb7a83f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "Welcome to our ARC course \"Learning to programme with Python\".\n",
@@ -44,10 +46,11 @@
    "cell_type": "markdown",
    "id": "a1351210",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# The Python Environment\n",
@@ -68,10 +71,11 @@
    "cell_type": "markdown",
    "id": "df718452",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>0.</ins> Introduction"
@@ -81,10 +85,11 @@
    "cell_type": "markdown",
    "id": "771379de",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Course objectives"
@@ -94,10 +99,11 @@
    "cell_type": "markdown",
    "id": "3c18c3fa",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "By the end of this course you should know:\n",
@@ -113,10 +119,11 @@
    "cell_type": "markdown",
    "id": "3d299576",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Useful resources"
@@ -126,10 +133,11 @@
    "cell_type": "markdown",
    "id": "3bf09837",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### Materials used and recommended:\n",
@@ -143,10 +151,11 @@
    "cell_type": "markdown",
    "id": "04744c33",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     " - The top results are often filled with SEO sites\n",
@@ -162,10 +171,11 @@
    "cell_type": "markdown",
    "id": "3f920e71",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Programming crash course"
@@ -175,10 +185,11 @@
    "cell_type": "markdown",
    "id": "b8752a44",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Programming means: make the computer do the work for you!"
@@ -188,10 +199,11 @@
    "cell_type": "markdown",
    "id": "e2fdc0dd",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     " - Do the maths\n",
@@ -206,10 +218,11 @@
    "cell_type": "markdown",
    "id": "4f4494de",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Running code in a compiled language (such as C)"
@@ -219,7 +232,11 @@
    "cell_type": "markdown",
    "id": "f2dc926b",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Write your code in a high-level programming language.\n",
@@ -231,10 +248,11 @@
    "cell_type": "markdown",
    "id": "a0738471",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Running code in an interpreted language (such as Python)"
@@ -244,10 +262,11 @@
    "cell_type": "markdown",
    "id": "5c7cf173",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "1. Write your code in high-level programming language.\n",
@@ -258,10 +277,11 @@
    "cell_type": "markdown",
    "id": "08a4a10d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Python can be executed in different ways\n",
@@ -272,10 +292,11 @@
    "cell_type": "markdown",
    "id": "97039004",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "1. Create a `myname.py` file\n",
@@ -286,10 +307,11 @@
    "cell_type": "markdown",
    "id": "1b55bb40",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "#### interactive or ipython session:\n",
@@ -361,10 +383,11 @@
    "cell_type": "markdown",
    "id": "f559c086",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "##### Now it is markdown and the `#` indicates a header (or `##`, etc., up to 6 times, with smaller font sizes)"
@@ -374,10 +397,11 @@
    "cell_type": "markdown",
    "id": "79229111",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>**Part I**</ins>"
@@ -387,13 +411,30 @@
    "cell_type": "markdown",
    "id": "c70e7ed6",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>1.</ins> Basics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30b16916",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "In this section we will look into the very basics of programming, to give you the foundations\n",
+    "to start from. A lot of it will be transferrable to other programming languages,\n",
+    "even if the exact syntax, the way how you write things down, changes."
    ]
   },
   {
@@ -415,10 +456,11 @@
    "cell_type": "markdown",
    "id": "7ccef7c6",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "- Strings: \"Heinz\", 'Banana', 'He said \"Hello\"'\n",
@@ -431,10 +473,11 @@
    "cell_type": "markdown",
    "id": "e07d8c5a",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Variables\n",
@@ -445,10 +488,11 @@
    "cell_type": "markdown",
    "id": "29bff5cf",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "- \u201cI reserve a space in memory for my data bit, and I call it \n",
@@ -460,10 +504,11 @@
    "cell_type": "markdown",
    "id": "51092a73",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Print type of a variable"
@@ -540,10 +585,11 @@
    "cell_type": "markdown",
    "id": "46b8ba58",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Try to assign the data types at the following qr code"
@@ -553,7 +599,11 @@
    "cell_type": "markdown",
    "id": "8dc654b8",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "Try not to overthink. If something is ambiguous pick what fits best\n",
@@ -712,28 +762,29 @@
    "cell_type": "markdown",
    "id": "a4512e52",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Basic operators\n",
-    "New values can be obtained by applying operators to old values, for example, mathematical operators on numerical data types `int` or `float`."
+    "New values can be obtained by applying operators to old values, for example, mathematical operators on numerical data types `int` or `float`:"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "bafdcfb2",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "- String: concatenation with `+`\n",
-    "- Bool: `and`, `or`, `not`\n",
     "- Numerical data: `+`, `-`, `*`, `/`, `%`, `**`, built-in functions `abs`, ...\n",
     "- Order of execution:\n",
     "    1. `()`\n",
@@ -749,10 +800,11 @@
    "cell_type": "markdown",
    "id": "d1091173",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Comments (and documentation)\n",
@@ -764,9 +816,11 @@
    "execution_count": null,
    "id": "ab4e37e2",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -789,10 +843,11 @@
    "cell_type": "markdown",
    "id": "3645d572",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Debugging and Types of Errors"
@@ -802,10 +857,11 @@
    "cell_type": "markdown",
    "id": "8afa6f79",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "<center>\n",
@@ -825,10 +881,11 @@
    "cell_type": "markdown",
    "id": "1f4dfa6d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -838,7 +895,11 @@
    "cell_type": "markdown",
    "id": "6277b6c2",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
    },
    "source": [
     "### _Exercises_"
@@ -883,7 +944,6 @@
    "execution_count": null,
    "id": "1ee8a92f",
    "metadata": {
-    "editable": true,
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
@@ -914,7 +974,6 @@
    "execution_count": null,
    "id": "15006274",
    "metadata": {
-    "editable": true,
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
@@ -924,20 +983,6 @@
    "outputs": [],
    "source": [
     "# What happens if you mix numbers and bools in arithmetic expressions?\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6bf1c0b8",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    },
-    "tags": []
-   },
-   "source": [
-    "True is converted to one and False is converted to zero"
    ]
   },
   {
@@ -1129,10 +1174,11 @@
    "cell_type": "markdown",
    "id": "c1b5c739",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>2.</ins> Functions"
@@ -1142,10 +1188,11 @@
    "cell_type": "markdown",
    "id": "3f6b80d9",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "A function is a block of reusable code that performs a specific task. Functions help reduce repetition and make code easier to manage. A function is defined using the `def` keyword."
@@ -1155,7 +1202,11 @@
    "cell_type": "markdown",
    "id": "383ac2a1",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "* You can pass data to functions (parameters).\n",
@@ -1167,7 +1218,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2ab9f7d9",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Function to add two numbers\n",
@@ -1183,10 +1240,11 @@
    "cell_type": "markdown",
    "id": "2a8095f4",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -1244,10 +1302,11 @@
    "cell_type": "markdown",
    "id": "84db8e18",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>3.</ins> Getting Data in and out"
@@ -1255,12 +1314,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2d579678-303c-45c0-8ec1-2233f774b99a",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Most times, we do not want to explicitly write our data into our code, which is also called \"hardcoding\", and has a bad reputation.\n",
+    "\n",
+    "Instead, we want to be able to provide data during runtime, and have a general program that is able to process the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9c90ef10",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## User input\n",
@@ -1310,10 +1386,11 @@
    "cell_type": "markdown",
    "id": "81998d75",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Reading and writing files"
@@ -1323,10 +1400,11 @@
    "cell_type": "markdown",
    "id": "415ad1e8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "```python\n",
@@ -1347,10 +1425,11 @@
    "cell_type": "markdown",
    "id": "3f9c2877",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Writing files and formatting strings (C-style)"
@@ -1361,7 +1440,6 @@
    "execution_count": null,
    "id": "f45fde6e",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -1381,10 +1459,11 @@
    "cell_type": "markdown",
    "id": "0d884b3f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "see also [https://www.learnpython.org/en/String\\_Formatting](https://www.learnpython.org/en/String_Formatting)"
@@ -1394,10 +1473,11 @@
    "cell_type": "markdown",
    "id": "16c995a4",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Writing files (f-strings)"
@@ -1428,10 +1508,11 @@
    "cell_type": "markdown",
    "id": "4db7b7e2",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "see also [f-strings](https://realpython.com/python-f-strings/)"
@@ -1441,10 +1522,11 @@
    "cell_type": "markdown",
    "id": "a7533130",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Reading files"
@@ -1477,10 +1559,11 @@
    "cell_type": "markdown",
    "id": "a94ee2ee",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -1490,7 +1573,11 @@
    "cell_type": "markdown",
    "id": "667c37bc",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
    },
    "source": [
     "### _Exercises_"
@@ -1500,10 +1587,11 @@
    "cell_type": "markdown",
    "id": "be0762cb",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "Here are some exercise ideas for \"Getting data in and out\":\n",
@@ -1530,10 +1618,11 @@
    "cell_type": "markdown",
    "id": "372a5ff1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "# <ins>4.</ins> Data structures"
@@ -1543,7 +1632,11 @@
    "cell_type": "markdown",
    "id": "1dda0b37",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "Python can work not only with basic data types mentioned before, but also with compound ones. Compound data types in Python are a powerful tool for organizing and storing data. Among the most commonly used are _lists_ and _dictionaries_. `For`-loops described in the next section often iterate over elements of lists or pairs of keys and values in dictionaries. But they can also iterate over a series of numbers generated for indexing or calculations by the `range()` function."
@@ -1553,10 +1646,11 @@
    "cell_type": "markdown",
    "id": "bf322501",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Lists"
@@ -1566,7 +1660,11 @@
    "cell_type": "markdown",
    "id": "4eea3782",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "_Lists_ are ordered collections of items."
@@ -1777,10 +1875,11 @@
    "cell_type": "markdown",
    "id": "80bb51c1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## _Range()_ function"
@@ -1790,7 +1889,11 @@
    "cell_type": "markdown",
    "id": "11ddd405",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "The `range()` function in Python is used to generate a sequence of numbers. It takes up to three arguments: `start`, `stop`, and `step`. By default, `start` is 0, `step` is 1, and the sequence ends just before the `stop` value."
@@ -1800,7 +1903,11 @@
    "cell_type": "markdown",
    "id": "2a95ec20",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "* `range(stop)`: Generates numbers from 0 to stop - 1.\n",
@@ -1814,10 +1921,11 @@
    "cell_type": "markdown",
    "id": "f85dc66b",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -1827,7 +1935,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "15c025b6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "range(10)"
@@ -1837,7 +1951,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f82ab219",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(10))"
@@ -1847,7 +1967,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0b6a1718",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(1,10))"
@@ -1857,7 +1983,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51dbf5d6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(3,7))"
@@ -1867,7 +1999,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2711d0ef",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(2,15,3))"
@@ -1877,7 +2015,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1564575c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(9,2,-1))"
@@ -1887,10 +2031,11 @@
    "cell_type": "markdown",
    "id": "9d8538d8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Have a Play!"
@@ -1900,7 +2045,11 @@
    "cell_type": "markdown",
    "id": "bf596194",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
    },
    "source": [
     "### _Exercises_"
@@ -1984,7 +2133,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -2007,44 +2156,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32e96a87-2d10-4fde-9d13-c3e805753b12",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "##### _<ins>Notes:</ins>_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "da74c8ad-9e71-41b2-8dd0-8e3ec967678b",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "These operators become crucial when writing more complex conditions in `if`-statements."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "74af5f47-ab75-4df1-91b8-3190bedc2ca6",
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "### _<ins>Examples:</ins>_ Comparisons"
+    "### Comparisons"
    ]
   },
   {
@@ -2123,30 +2244,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fed5023-5d86-4427-96b0-555924659ed1",
-   "metadata": {
-    "editable": false
-   },
-   "source": [
-    "##### _<ins>Notes:</ins>_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6452908a-8d20-43c3-a515-8a524a526d9d",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "**Common mistake:** Using `=` (assignment) instead of `==` (comparison)!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "396617ca",
    "metadata": {
     "editable": false,
@@ -2156,7 +2253,7 @@
     "tags": []
    },
    "source": [
-    "### _<ins>Examples</ins>:_ Logical operators"
+    "### Logical operators"
    ]
   },
   {
@@ -2279,7 +2376,7 @@
     "editable": false,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -2299,7 +2396,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -2323,20 +2420,6 @@
    "outputs": [],
    "source": [
     "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1fabcdd8-baea-43bd-b61e-7af35de49381",
-   "metadata": {
-    "editable": false,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "source": [
-    "This exercise demonstrates how comparison and logical operators work together - exactly what you'll use in `if`-statements next!"
    ]
   },
   {
@@ -2375,10 +2458,11 @@
    "cell_type": "markdown",
    "id": "0b373d79",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "Examples of conditional operators (expressions and their descriptions):\n",
@@ -2399,10 +2483,11 @@
    "cell_type": "markdown",
    "id": "077114b1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -2430,7 +2515,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ffc89ad1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "grade = int(input('Enter your score: '))"
@@ -2492,10 +2583,11 @@
    "cell_type": "markdown",
    "id": "24654b8b",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## _For_-loops"
@@ -2505,7 +2597,11 @@
    "cell_type": "markdown",
    "id": "634a4e09",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "A `for`-loop iterates over a sequence (like a list, string, or range) and executes a block of code for each item in that sequence."
@@ -2515,7 +2611,11 @@
    "cell_type": "markdown",
    "id": "7be926fd",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "* A `for`-loop is a _control_ instruction used for iteration and repetition\n",
@@ -2531,10 +2631,11 @@
    "cell_type": "markdown",
    "id": "82b16990",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -2544,7 +2645,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e64c509",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Iterating over a list\n",
@@ -2587,10 +2694,11 @@
    "cell_type": "markdown",
    "id": "fc875a1f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## _While_-loops"
@@ -2600,7 +2708,11 @@
    "cell_type": "markdown",
    "id": "96ad7d45",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "A `while`-loop keeps executing a block of code as long as its condition remains true. It's commonly used for indefinite loops where the number of iterations isn\u2019t known beforehand."
@@ -2610,7 +2722,11 @@
    "cell_type": "markdown",
    "id": "f8ace486",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "* A `while`-loop is a _control_ instruction ideal for _indefinite loops_ when we don\u2019t know when it ends\n",
@@ -2625,10 +2741,11 @@
    "cell_type": "markdown",
    "id": "e8b309d0",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -2681,10 +2798,11 @@
    "cell_type": "markdown",
    "id": "d27544ee",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "## Have a Play!"
@@ -2710,7 +2828,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -2739,7 +2857,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -2768,7 +2886,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -2797,7 +2915,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -2838,7 +2956,11 @@
    "cell_type": "markdown",
    "id": "d029a1c0",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "To run python outside of the JupyterLite environment you need to install it locally. As with a lot of large programming languages there are multiple solutions to do this. The two common families of solutions are python with pip and conda/mamba."
@@ -2848,7 +2970,11 @@
    "cell_type": "markdown",
    "id": "e8556ab8",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "| Feature | **Python with pip** | **Conda/Mamba** |\n",
@@ -2870,10 +2996,11 @@
    "cell_type": "markdown",
    "id": "9bf355f1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Installing Python and pip"
@@ -2883,7 +3010,11 @@
    "cell_type": "markdown",
    "id": "d0b30d43",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On Windows:"
@@ -2893,7 +3024,11 @@
    "cell_type": "markdown",
    "id": "e0a9656c",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Go to https://www.python.org/downloads/) and choose the latest stable installer for Windows (for example, \u201cWindows installer (64-bit)\u201d).\n",
@@ -2913,7 +3048,11 @@
    "cell_type": "markdown",
    "id": "b03e4874",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On Linux (Ubuntu/Debian-based):"
@@ -2923,7 +3062,11 @@
    "cell_type": "markdown",
    "id": "546d664c",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Open a terminal.\n",
@@ -2947,7 +3090,11 @@
    "cell_type": "markdown",
    "id": "d25e9eaa",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On macOS:"
@@ -2957,7 +3104,11 @@
    "cell_type": "markdown",
    "id": "32384276",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Visit https://www.python.org/downloads/ and download the macOS installer (e.g., \u201cmacOS 64-bit universal2 installer\u201d).\n",
@@ -2977,10 +3128,11 @@
    "cell_type": "markdown",
    "id": "6ad36f9c",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Installing and Running Jupyter Notebooks"
@@ -2990,7 +3142,11 @@
    "cell_type": "markdown",
    "id": "88323ba7",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Once Python is installed (whether from python.org, your Linux package manager, or Anaconda), you can install Jupyter Lab as follows:\n",
@@ -3015,10 +3171,11 @@
    "cell_type": "markdown",
    "id": "1ea7de96",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Installing Mamba (via Miniforge)"
@@ -3028,7 +3185,11 @@
    "cell_type": "markdown",
    "id": "88f8fa02",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On Windows:"
@@ -3038,7 +3199,11 @@
    "cell_type": "markdown",
    "id": "bc5d5add",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Go to https://github.com/conda-forge/miniforge and download the Miniforge3 installer for Windows (e.g., \"Miniforge3-Windows-x86_64.exe\").\n",
@@ -3059,7 +3224,11 @@
    "cell_type": "markdown",
    "id": "a9daafa9",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On Linux (Ubuntu/Debian-based and others):"
@@ -3069,7 +3238,11 @@
    "cell_type": "markdown",
    "id": "ba271553",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Open a terminal and download the installer:\n",
@@ -3102,7 +3275,11 @@
    "cell_type": "markdown",
    "id": "f2e714e4",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "#### On macOS:"
@@ -3112,7 +3289,11 @@
    "cell_type": "markdown",
    "id": "232aee40",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Download the installer from https://github.com/conda-forge/miniforge:\n",
@@ -3148,10 +3329,11 @@
    "cell_type": "markdown",
    "id": "68d32a65",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
-    "editable": false
+    "tags": []
    },
    "source": [
     "### Installing and Running Jupyter Notebooks with Mamba"
@@ -3161,7 +3343,11 @@
    "cell_type": "markdown",
    "id": "38068a3a",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "1. Once Miniforge/Mamba is installed, you can install JupyterLab in a new environment for your project:\n",
@@ -3186,7 +3372,11 @@
    "cell_type": "markdown",
    "id": "ac3d4b98",
    "metadata": {
-    "editable": false
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": []
   }

--- a/Basics_filled.ipynb
+++ b/Basics_filled.ipynb
@@ -3151,7 +3151,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -3165,7 +3165,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -3199,24 +3199,6 @@
    },
    "source": [
     "Now that we can create boolean values through comparisons, we can combine them using logical operators."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02a0ed98",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Adding booleans\n",
-    "True+False"
    ]
   },
   {
@@ -3276,6 +3258,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "02a0ed98",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Adding booleans\n",
+    "True+False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "918b8f36-0c33-43e5-830b-8036021b822f",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Combining comparisons\n",
+    "Logical operators are commonly used to combine comparisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "980d102d-ab45-4277-a5cc-1a87da38a217",
    "metadata": {
     "editable": true,
@@ -3310,7 +3323,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -3325,7 +3338,7 @@
     "editable": false,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -3397,7 +3410,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -3411,7 +3424,7 @@
    "metadata": {
     "editable": false,
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "notes"
     },
     "tags": []
    },
@@ -4420,7 +4433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/Basics_filled.ipynb
+++ b/Basics_filled.ipynb
@@ -409,9 +409,11 @@
    "cell_type": "markdown",
    "id": "ddb77cb8",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Demonstration of using _Jupyter_ notebook"
@@ -421,20 +423,14 @@
    "cell_type": "markdown",
    "id": "6be1345f",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "Jupyter works with cells such as these, which you execute with the play button or `Shift/Ctrl + Enter`:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9d12ce9",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -446,7 +442,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -456,19 +453,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a8f48be",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "12764b89",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "If the box on the left is empty, you have not executed it. Otherwise a number indicates in which order the execution took place.\n",
@@ -555,9 +546,11 @@
    "cell_type": "markdown",
    "id": "c515267a",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Basic data types\n",
@@ -675,19 +668,17 @@
   {
    "cell_type": "markdown",
    "id": "98edd5e0",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "The `print` function which outputs text or variable values to the screen so they are visible while the program runs.\n",
     "\n",
     "This is one way to allow you to see what your program is doing as it executes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dace0de0",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -699,22 +690,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# print statement \"Hello\"\n",
     "print(\"Hello\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3ea6bf5e",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -726,23 +708,14 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# put the content of the print statement in a variable\n",
     "my_string = \"Hello\"\n",
     "print(my_string)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1d6afc5",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -754,7 +727,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -764,19 +738,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7512901d",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "66fe12b1",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -861,20 +829,14 @@
    "cell_type": "markdown",
    "id": "610b7c33",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Add integers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bdba3aca",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -886,22 +848,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding two integers (2 and 5)\n",
     "print(2+5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e38b2a6f",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -913,22 +866,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding integers to a string (\"2+5 = \") naively\n",
     "print(\"2+5 = \" + 2 + 5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6cf46063",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -940,7 +884,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -950,19 +895,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1401fd54",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "c7028027",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -984,21 +923,14 @@
    "cell_type": "markdown",
    "id": "99bc4e26",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Boolean type"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ab9ccbc",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1010,22 +942,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# boolean have to be capitalized\n",
     "type(true)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f9c2fa7",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1037,22 +960,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Checking the type of a boolean\n",
     "type(True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8f7263f3",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1064,22 +978,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding a boolean to an integer\n",
     "1+True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1a0d4827",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1091,7 +996,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1101,19 +1007,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2b76987",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "0f3bcffd",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1354,9 +1254,11 @@
    "cell_type": "markdown",
    "id": "264f4cf3",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "You could try\n",
@@ -1402,20 +1304,14 @@
    "cell_type": "markdown",
    "id": "bf4d52bb",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "31296375",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1427,7 +1323,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1437,30 +1334,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1241418e",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4757c3c2",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1cfa3f7e",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1472,7 +1355,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1484,19 +1368,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc0685df",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "2bcb76ab",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1506,9 +1384,11 @@
    "cell_type": "markdown",
    "id": "6bf1c0b8",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "True is converted to one and False is converted to zero"
@@ -1518,20 +1398,14 @@
    "cell_type": "markdown",
    "id": "3060c201",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "39136b9e",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1543,7 +1417,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1556,30 +1431,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "494572b1",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "8ffe919b",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### _Example solution_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d3bb0cdf",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1591,7 +1452,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1607,19 +1469,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6acfd6a8",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ca7a2bf1",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### _Example solutions_\n",
@@ -1630,20 +1486,14 @@
    "cell_type": "markdown",
    "id": "5280e49d",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### 1. Syntax Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "505b62e1",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1655,7 +1505,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1664,30 +1515,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4101da3d",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1786772f",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### 2. Semantic Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e925ba8",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1699,7 +1536,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1708,30 +1546,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "689fbc03",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "5234c07e",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### 3. Runtime Error"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "80174eef",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -1743,7 +1567,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1753,19 +1578,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3abfff6f",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "2f3d5124",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Interlude: Indented blocks in python\n",
@@ -1868,9 +1687,11 @@
    "cell_type": "markdown",
    "id": "6bd208c9",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _Exercises_\n",
@@ -1878,9 +1699,7 @@
     "**1)** Write a function that converts Celsius to Fahrenheit. Use the formula  \n",
     "$\n",
     "\\text{Fahrenheit} = (\\text{Celsius} \\times \\frac{9}{5}) + 32\n",
-    "$\n",
-    "\n",
-    "<!-- #solution -->"
+    "$"
    ]
   },
   {
@@ -1889,7 +1708,11 @@
    "id": "a4b09ae2",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1902,19 +1725,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ca4bf11",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "698e44f7",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>**Part II**</ins>"
@@ -2395,9 +2212,11 @@
    "cell_type": "markdown",
    "id": "99ce3685",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "* A list contains items separated by commas and enclosed with square brackets `[]`\n",
@@ -2410,14 +2229,14 @@
    "cell_type": "markdown",
    "id": "a7d14dc3",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "### _<ins>Examples:</ins>_\n",
-    "\n",
-    "<!-- #solution -->"
+    "### _<ins>Examples:</ins>_"
    ]
   },
   {
@@ -2439,16 +2258,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "027f913a",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b7cbcdd2",
@@ -2467,16 +2276,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "00c19747",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2bec453c",
@@ -2485,22 +2284,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print an element of the list. Note: use [] not () for item indexing\n",
     "print(my_list[3])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce970cc8",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2512,22 +2302,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print the first element of the list. Indexing starts with 0!\n",
     "print(my_list[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7e5c8937",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2539,22 +2320,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print the last element of the list using backward indexing\n",
     "print(my_list[-1])  # Go backwards"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19332ca8",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2566,22 +2338,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Print an internal slice of the list\n",
     "print(my_list[1:4]) # Include first, exclude last"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c0194d5b",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2593,7 +2356,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2602,22 +2366,16 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "b687058f",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ca455b93",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2628,22 +2386,16 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "826d0594",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "86f486b3",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2652,22 +2404,16 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "cd364758",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0aa952b1",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2677,19 +2423,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63c23a98",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ea0a97df",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -2869,11 +2609,15 @@
   {
    "cell_type": "markdown",
    "id": "82edf40e",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "**1) Lists**: Create a list of numbers from 1 to 20 and then print the elements at every second index.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**1) Lists**: Create a list of numbers from 1 to 20 and then print the elements at every second index."
    ]
   },
   {
@@ -2882,7 +2626,11 @@
    "id": "bd25dc80",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2892,30 +2640,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a5201641",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "958677ed",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "**2) Range**: Create a list of even numbers between 10 and 30 using `range()`, and print it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f15c5ea7",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -2927,7 +2661,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2939,9 +2674,11 @@
    "cell_type": "markdown",
    "id": "5efb8831",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>5.</ins> Conditional and control flow statements"
@@ -3007,7 +2744,6 @@
    "id": "74af5f47-ab75-4df1-91b8-3190bedc2ca6",
    "metadata": {
     "editable": true,
-    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -3118,7 +2854,6 @@
    "id": "396617ca",
    "metadata": {
     "editable": true,
-    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -3143,14 +2878,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "2162f785",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "02a0ed98",
@@ -3159,22 +2886,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Adding booleans\n",
     "True+False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bf01971",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -3186,22 +2904,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Logical AND\n",
     "True and False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8485e6f8",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -3213,22 +2922,13 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# Logical OR\n",
     "True or False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c028c985",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
    ]
   },
   {
@@ -3240,7 +2940,8 @@
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3252,7 +2953,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "980d102d-ab45-4277-a5cc-1a87da38a217",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Combining comparisons\n",
@@ -3275,19 +2982,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce8e6377",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "d4c72581",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"

--- a/Basics_filled.ipynb
+++ b/Basics_filled.ipynb
@@ -984,6 +984,7 @@
    "cell_type": "markdown",
    "id": "99bc4e26",
    "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -1128,156 +1129,6 @@
    },
    "source": [
     "Let's take a closer look at booleans. They seem a bit boring, but we will see later that they are really essential for programming. The values are case sensitive, so you have to make sure to write``True`` and ``False`` with capital letters. You will also have noticed that ``True`` has the numerical value one, and ``False`` is zero."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "396617ca",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### _<ins>Example</ins>:_ Boolean operators"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2162f785",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02a0ed98",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Adding booleans\n",
-    "True+False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7bf01971",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8fe2a9fa",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Logical AND\n",
-    "True and False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8485e6f8",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a3cd6635",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Logical OR\n",
-    "True or False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c028c985",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "<!-- #solution -->"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "646ecc5a",
-   "metadata": {
-    "editable": true,
-    "remove_code": "non-comments",
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Negating boolean\n",
-    "not True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce8e6377",
-   "metadata": {},
-   "source": [
-    "<!-- #endsolution -->"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4c72581",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "notes"
-    }
-   },
-   "source": [
-    "##### _<ins>Notes:</ins>_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "58c185a7",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "notes"
-    }
-   },
-   "source": [
-    "While we can add booleans, the more appropriate operations are logical operations. You can invert the value with ``not``, and combine two values logically with ``and`` and ``or``."
    ]
   },
   {
@@ -2863,9 +2714,11 @@
    "cell_type": "markdown",
    "id": "abf28fb3",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -2875,9 +2728,11 @@
    "cell_type": "markdown",
    "id": "2f6b1207",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
-    }
+    },
+    "tags": []
    },
    "source": [
     "[https://www.w3schools.com/python/python_lists.asp](https://www.w3schools.com/python/python_lists.asp)\n",
@@ -3094,11 +2949,446 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24d65380",
+   "id": "b70dd974-edaf-4754-9584-93f50921e743",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Comparisons and Logical Operators\n",
+    "Before we can make decisions in our code, we need to be able to compare values. Python provides several comparison operators that evaluate to boolean values (`True` or `False`). Comparison operators always return a boolean value (`True` or `False`). These are essential for making decisions in your code:\n",
+    "* `>` greater than\n",
+    "* `<` less than\n",
+    "* `==` equal to (note: two equals signs!)\n",
+    "* `!=` not equal to\n",
+    "* `>=` greater than or equal to\n",
+    "* `<=` less than or equal to\n",
+    "\n",
+    "Logical operators combine boolean values:\n",
+    "\n",
+    "* `and`: Returns `True` only if both conditions are `True`\n",
+    "* `or`: Returns `True` if at least one condition is `True`\n",
+    "* `not`: Inverts the boolean value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32e96a87-2d10-4fde-9d13-c3e805753b12",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da74c8ad-9e71-41b2-8dd0-8e3ec967678b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "These operators become crucial when writing more complex conditions in `if`-statements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74af5f47-ab75-4df1-91b8-3190bedc2ca6",
+   "metadata": {
+    "editable": true,
+    "jp-MarkdownHeadingCollapsed": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### _<ins>Examples:</ins>_ Comparisons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2cceb3d-3087-4a36-97de-e2e812c591e4",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Basic comparisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0b84d51-59ca-4825-9246-a2a9577a2c30",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x = 5\n",
+    "y = 10\n",
+    "\n",
+    "print(x > y)   # Greater than: False\n",
+    "print(x < y)   # Less than: True\n",
+    "print(x == y)  # Equal to: False\n",
+    "print(x != y)  # Not equal to: True\n",
+    "print(x >= 5)  # Greater than or equal: True\n",
+    "print(x <= 10) # Less than or equal: True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c907d157-f6a7-4b69-8f6e-93c1ff5fc94e",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Comparisons with strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e71c33a-f7dc-41f7-b440-dd5b3b1694b4",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "name1 = \"Alice\"\n",
+    "name2 = \"Bob\"\n",
+    "\n",
+    "print(name1 == name2)  # False\n",
+    "print(name1 != name2)  # True\n",
+    "# Strings can be compared alphabetically\n",
+    "print(name1 < name2)   # True (A comes before B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fed5023-5d86-4427-96b0-555924659ed1",
+   "metadata": {},
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6452908a-8d20-43c3-a515-8a524a526d9d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "**Common mistake:** Using `=` (assignment) instead of `==` (comparison)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "396617ca",
+   "metadata": {
+    "editable": true,
+    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "slide"
+    },
+    "tags": []
+   },
+   "source": [
+    "### _<ins>Examples</ins>:_ Logical operators"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89b36ecb-cdca-403c-956a-fb3a76fd020d",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Now that we can create boolean values through comparisons, we can combine them using logical operators."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2162f785",
+   "metadata": {},
+   "source": [
+    "<!-- #solution -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02a0ed98",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
     }
+   },
+   "outputs": [],
+   "source": [
+    "# Adding booleans\n",
+    "True+False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf01971",
+   "metadata": {},
+   "source": [
+    "<!-- #endsolution -->\n",
+    "\n",
+    "<!-- #solution -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fe2a9fa",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Logical AND\n",
+    "True and False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8485e6f8",
+   "metadata": {},
+   "source": [
+    "<!-- #endsolution -->\n",
+    "\n",
+    "<!-- #solution -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3cd6635",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Logical OR\n",
+    "True or False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c028c985",
+   "metadata": {},
+   "source": [
+    "<!-- #endsolution -->\n",
+    "\n",
+    "<!-- #solution -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "646ecc5a",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Negating boolean\n",
+    "not True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "980d102d-ab45-4277-a5cc-1a87da38a217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combining comparisons\n",
+    "age = 25\n",
+    "has_license = True\n",
+    "\n",
+    "# Using AND - both conditions must be True\n",
+    "can_drive = age >= 18 and has_license\n",
+    "print(f\"Can drive: {can_drive}\")  # True\n",
+    "\n",
+    "# Using OR - at least one condition must be True\n",
+    "temperature = 35\n",
+    "is_hot = temperature > 30 or temperature < 0\n",
+    "print(f\"Extreme temperature: {is_hot}\")  # True\n",
+    "\n",
+    "# Using NOT - inverts the boolean value\n",
+    "is_minor = not (age >= 18)\n",
+    "print(f\"Is minor: {is_minor}\")  # False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce8e6377",
+   "metadata": {},
+   "source": [
+    "<!-- #endsolution -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4c72581",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "notes"
+    }
+   },
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58c185a7",
+   "metadata": {
+    "editable": true,
+    "jp-MarkdownHeadingCollapsed": true,
+    "slideshow": {
+     "slide_type": "notes"
+    },
+    "tags": []
+   },
+   "source": [
+    "While we can add booleans, the more appropriate operations are logical operations. You can invert the value with ``not``, and combine two values logically with ``and`` and ``or``. These operators become crucial when writing more complex conditions in `if`-statements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6e41b34-6325-41d8-ac88-d12f6a4a0b4f",
+   "metadata": {
+    "editable": true,
+    "jp-MarkdownHeadingCollapsed": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### <ins>_Exercises_</ins>:\n",
+    "\n",
+    "You could try:\n",
+    " - **comparing different data types** - what happens when you compare a string with a number?\n",
+    " - **chaining comparisons** - try expressions like `1 < x < 10`\n",
+    " - **combining multiple conditions** - use `and`, `or`, and `not` together\n",
+    " - what happens if you mix numbers and bools in arithmetic expressions?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a50a84-306d-45dd-a1f4-28fe86b67360",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### <ins>_Bridge Exercise</ins>:_ Temperature Checker\n",
+    "Write code that checks if a temperature is comfortable (between 18°C and 25°C):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "795e6224-3e3f-40ad-ac82-0c677f48ed1d",
+   "metadata": {
+    "editable": true,
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "temperature = 22\n",
+    "\n",
+    "is_comfortable = temperature >= 18 and temperature <= 25\n",
+    "# Alternative: is_comfortable = 18 <= temperature <= 25\n",
+    "\n",
+    "print(f\"Temperature is comfortable: {is_comfortable}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fabcdd8-baea-43bd-b61e-7af35de49381",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "This exercise demonstrates how comparison and logical operators work together - exactly what you'll use in `if`-statements next!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24d65380",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
    },
    "source": [
     "## _If_-statements"
@@ -3107,9 +3397,19 @@
   {
    "cell_type": "markdown",
    "id": "86caca1c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "An `if`-statement evaluates a condition (an expression that returns `True` or `False`) and executes a block of code if the condition is true. Python uses conditional operators, colons `:` and indentation to define blocks of code. The `elif` (else if) statement allows checking multiple conditions sequentially. Once a condition evaluates to `True`, the rest are ignored. If no conditions are true, you can use an `else` statement as a fallback."
+    "An `if`-statement evaluates a condition (an expression that returns `True` or `False`) and executes a block of code if the condition is true.\n",
+    "\n",
+    "**Remember:** We create these conditions using the comparison operators (`>`, `<`, `==`, `!=`, `>=`, `<=`) and logical operators (`and`, `or`, `not`) that we've just learned.\n",
+    "\n",
+    "Python uses conditional operators, colons `:` and indentation to define blocks of code. The `elif` (else if) statement allows checking multiple conditions sequentially. Once a condition evaluates to `True`, the rest are ignored. If no conditions are true, you can use an `else` statement as a fallback."
    ]
   },
   {
@@ -3151,7 +3451,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "02da94e1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "x = 10\n",
@@ -3173,7 +3479,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b3cfe09f",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# using only `if`\n",
@@ -3193,7 +3505,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c3505308",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# using `if`, `elif` and `else`\n",
@@ -3275,7 +3593,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2e7d84a5",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "my_list = [\"Andrew\", \"John\", \"Kate\"]\n",
@@ -3341,7 +3665,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "078c8e13",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "count = 0\n",
@@ -3354,7 +3684,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21d1a0d2",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "n=1\n",
@@ -3384,9 +3720,11 @@
    "cell_type": "markdown",
    "id": "7a2f1f84",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _Exercises_"
@@ -3396,20 +3734,14 @@
    "cell_type": "markdown",
    "id": "c60fe3a1",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "**1) `If`-statements**: Write a program that asks for a user's age and prints whether the person is a minor, an adult, or a senior citizen."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f9dfcb0",
-   "metadata": {},
-   "source": [
-    "<!-- #solution -->"
    ]
   },
   {
@@ -3418,7 +3750,11 @@
    "id": "263767ef",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3435,16 +3771,14 @@
    "cell_type": "markdown",
    "id": "1cfae422",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**2) `For`-loops**: Use a `for`-loop to print the square of numbers from 1 to 10.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**2) `For`-loops**: Use a `for`-loop to print the square of numbers from 1 to 10."
    ]
   },
   {
@@ -3453,7 +3787,11 @@
    "id": "2f67bcec",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3465,16 +3803,14 @@
    "cell_type": "markdown",
    "id": "87c1529d",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**3) `While`-loops**: Write a program that keeps asking the user for a number and prints the number. Stop when the user enters a negative number.\n",
-    "\n",
-    "<!-- #solution -->"
+    "**3) `While`-loops**: Write a program that keeps asking the user for a number and prints the number. Stop when the user enters a negative number."
    ]
   },
   {
@@ -3483,7 +3819,11 @@
    "id": "7d063a72",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3498,16 +3838,14 @@
    "cell_type": "markdown",
    "id": "db69b6c7",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
-    "<!-- #endsolution -->\n",
-    "\n",
-    "**4) Functions**: Write a program to calculate the factorial of a number\n",
-    "\n",
-    "<!-- #solution -->"
+    "**4) Functions**: Write a program to calculate the factorial of a number"
    ]
   },
   {
@@ -3516,7 +3854,11 @@
    "id": "7827b090",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments"
+    "remove_code": "non-comments",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -3879,7 +4221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,

--- a/Basics_filled.ipynb
+++ b/Basics_filled.ipynb
@@ -3051,7 +3051,7 @@
    "id": "795e6224-3e3f-40ad-ac82-0c677f48ed1d",
    "metadata": {
     "editable": true,
-    "remove_code": "non-comments",
+    "remove_code": "all",
     "slideshow": {
      "slide_type": ""
     },

--- a/Basics_filled.ipynb
+++ b/Basics_filled.ipynb
@@ -4,9 +4,11 @@
    "cell_type": "markdown",
    "id": "2d68459e",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "ARC course \"Learning to programme with Python\" (beginner level)\n",
@@ -18,9 +20,11 @@
    "cell_type": "markdown",
    "id": "fdb7a83f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "Welcome to our ARC course \"Learning to programme with Python\".\n",
@@ -42,9 +46,11 @@
    "cell_type": "markdown",
    "id": "a1351210",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "# The Python Environment\n",
@@ -65,9 +71,11 @@
    "cell_type": "markdown",
    "id": "e9ec6fd4",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "skip"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>Table of Contents</ins>"
@@ -77,9 +85,11 @@
    "cell_type": "markdown",
    "id": "df718452",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>0.</ins> Introduction"
@@ -89,9 +99,11 @@
    "cell_type": "markdown",
    "id": "771379de",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Course objectives"
@@ -101,9 +113,11 @@
    "cell_type": "markdown",
    "id": "3c18c3fa",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "By the end of this course you should know:\n",
@@ -119,9 +133,11 @@
    "cell_type": "markdown",
    "id": "c0514b2c",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "skip"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -131,9 +147,11 @@
    "cell_type": "markdown",
    "id": "7b442005",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     " - We'll talk about how to get a simple computer program running, the basics in terms of *data types*, *variables*, *if-statements* and *loops*, getting data in and out of the program, *functions* and *variable scope*, and a bit about *comments*, *error types* and their *handling*.\n",
@@ -144,9 +162,11 @@
    "cell_type": "markdown",
    "id": "3d299576",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Useful resources"
@@ -156,9 +176,11 @@
    "cell_type": "markdown",
    "id": "3bf09837",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### Materials used and recommended:\n",
@@ -172,9 +194,11 @@
    "cell_type": "markdown",
    "id": "10ed6bd0",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -184,9 +208,11 @@
    "cell_type": "markdown",
    "id": "491bafa3",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Here is a list of sources that were used when this course was prepared. It is great for self-study, and you can use it after this course to continue on your own.\n",
@@ -201,9 +227,11 @@
    "cell_type": "markdown",
    "id": "04744c33",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     " - The top results are often filled with SEO sites\n",
@@ -219,9 +247,11 @@
    "cell_type": "markdown",
    "id": "622ee930",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "_**Notes**_: Do not show search results. Just keep as small topic."
@@ -231,9 +261,11 @@
    "cell_type": "markdown",
    "id": "3f920e71",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Programming crash course"
@@ -243,9 +275,11 @@
    "cell_type": "markdown",
    "id": "b8752a44",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Programming means: make the computer do the work for you!"
@@ -255,9 +289,11 @@
    "cell_type": "markdown",
    "id": "e2fdc0dd",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     " - Do the maths\n",
@@ -272,9 +308,11 @@
    "cell_type": "markdown",
    "id": "4f4494de",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Running code in a compiled language (such as C)"
@@ -283,7 +321,13 @@
   {
    "cell_type": "markdown",
    "id": "f2dc926b",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Write your code in a high-level programming language.\n",
     "2. Translate into low-level (machine/assembly) language.\n",
@@ -294,9 +338,11 @@
    "cell_type": "markdown",
    "id": "aedfd931",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -306,9 +352,11 @@
    "cell_type": "markdown",
    "id": "e628804d",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Now, how do we get the computer to do these things for us? This is what we are doing: We write the program in a language that we as human beings (with some training) can understand. As the computer won't be able to understand the code that way, we then compile it, which means that we translate it into computer language. Then we execute the program and, given we have made no mistake, the computer will get working for us.  "
@@ -318,9 +366,11 @@
    "cell_type": "markdown",
    "id": "a0738471",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Running code in an interpreted language (such as Python)"
@@ -330,9 +380,11 @@
    "cell_type": "markdown",
    "id": "5c7cf173",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "1. Write your code in high-level programming language.\n",
@@ -343,9 +395,11 @@
    "cell_type": "markdown",
    "id": "f3e24e7f",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -355,9 +409,11 @@
    "cell_type": "markdown",
    "id": "ee728441",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Things can be made a little bit easier by using an interpreted scripting language instead of a compiled programming language.\n",
@@ -370,9 +426,11 @@
    "cell_type": "markdown",
    "id": "08a4a10d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Python can be executed in different ways\n",
@@ -383,9 +441,11 @@
    "cell_type": "markdown",
    "id": "97039004",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "1. Create a `myname.py` file\n",
@@ -396,9 +456,11 @@
    "cell_type": "markdown",
    "id": "1b55bb40",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "#### interactive or ipython session:\n",
@@ -409,7 +471,7 @@
    "cell_type": "markdown",
    "id": "ddb77cb8",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -423,7 +485,7 @@
    "cell_type": "markdown",
    "id": "6be1345f",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -455,7 +517,7 @@
    "cell_type": "markdown",
    "id": "12764b89",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -471,9 +533,11 @@
    "cell_type": "markdown",
    "id": "f559c086",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### Now it is markdown and the `#` indicates a header (or `##`, etc., up to 6 times, with smaller font sizes)"
@@ -483,9 +547,11 @@
    "cell_type": "markdown",
    "id": "5991825f",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -495,9 +561,11 @@
    "cell_type": "markdown",
    "id": "afa0e1ec",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     " - We have individual cells to run. To do so press the run button or `Shift + Enter`\n",
@@ -508,9 +576,11 @@
    "cell_type": "markdown",
    "id": "79229111",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>**Part I**</ins>"
@@ -520,9 +590,11 @@
    "cell_type": "markdown",
    "id": "c70e7ed6",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>1.</ins> Basics"
@@ -532,9 +604,11 @@
    "cell_type": "markdown",
    "id": "30b16916",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": ""
+    },
+    "tags": []
    },
    "source": [
     "In this section we will look into the very basics of programming, to give you the foundations\n",
@@ -546,7 +620,7 @@
    "cell_type": "markdown",
    "id": "c515267a",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -561,9 +635,11 @@
    "cell_type": "markdown",
    "id": "7ccef7c6",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "- Strings: \"Heinz\", 'Banana', 'He said \"Hello\"'\n",
@@ -576,9 +652,11 @@
    "cell_type": "markdown",
    "id": "dfa24114",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -588,9 +666,11 @@
    "cell_type": "markdown",
    "id": "2a84f2e3",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "When you are programming, you have to be clear about what type each item you are handling has. Each data type has different rules. In the most basic version, Python has the following data types:\n",
@@ -604,9 +684,11 @@
    "cell_type": "markdown",
    "id": "e07d8c5a",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Variables\n",
@@ -617,9 +699,11 @@
    "cell_type": "markdown",
    "id": "29bff5cf",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "- “I reserve a space in memory for my data bit, and I call it \n",
@@ -631,9 +715,11 @@
    "cell_type": "markdown",
    "id": "fb708d53",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -643,9 +729,11 @@
    "cell_type": "markdown",
    "id": "c8d0866e",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "The next essential concept you need to know for programming in Python are variables.\n",
@@ -657,9 +745,11 @@
    "cell_type": "markdown",
    "id": "51092a73",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Print type of a variable"
@@ -669,7 +759,7 @@
    "cell_type": "markdown",
    "id": "98edd5e0",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -740,9 +830,9 @@
    "cell_type": "markdown",
    "id": "66fe12b1",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -754,9 +844,11 @@
    "cell_type": "markdown",
    "id": "f3286701",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "In this example we see the print statement again. It will usually expect a string, or something that can be converted to a string.\n",
@@ -772,9 +864,11 @@
    "cell_type": "markdown",
    "id": "46b8ba58",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Example</ins>:_ Try to assign the data types at the following qr code"
@@ -783,7 +877,13 @@
   {
    "cell_type": "markdown",
    "id": "8dc654b8",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Try not to overthink. If something is ambiguous pick what fits best\n",
     "\n",
@@ -794,9 +894,11 @@
    "cell_type": "markdown",
    "id": "6d81fa96",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -806,9 +908,11 @@
    "cell_type": "markdown",
    "id": "6fc5a2b1",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Questions behind QR Code\n",
@@ -829,7 +933,7 @@
    "cell_type": "markdown",
    "id": "610b7c33",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -897,9 +1001,9 @@
    "cell_type": "markdown",
    "id": "c7028027",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -911,9 +1015,11 @@
    "cell_type": "markdown",
    "id": "fc6bf57f",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     " - As I said before, ``print`` expects a string or something that can be converted to a string. Here are some examples of what happens if I am dealing with integers. Please try each of these examples for yourself, and see what the output is. One will give you an error. In the 1st case, the interpreter recognises that I have two integers that want to be added together, and gives me the answer. The 2nd case produces an error and says ``TypeError: can only concatenate str (not \"int\") to str``. The plus sign actually means two different things for numbers and for strings! You can *glue* two strings together using the plus sign, and you can add two numbers together, as we would expect. The 3rd case shows how to explicitly cast a number to a string. We tell it ``add 2 and 5 together, make it a string, and concatenate it to the other string''."
@@ -923,7 +1029,7 @@
    "cell_type": "markdown",
    "id": "99bc4e26",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1009,9 +1115,9 @@
    "cell_type": "markdown",
    "id": "0f3bcffd",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -1023,9 +1129,11 @@
    "cell_type": "markdown",
    "id": "6dfc2b7e",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Let's take a closer look at booleans. They seem a bit boring, but we will see later that they are really essential for programming. The values are case sensitive, so you have to make sure to write``True`` and ``False`` with capital letters. You will also have noticed that ``True`` has the numerical value one, and ``False`` is zero."
@@ -1035,26 +1143,29 @@
    "cell_type": "markdown",
    "id": "a4512e52",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Basic operators\n",
-    "New values can be obtained by applying operators to old values, for example, mathematical operators on numerical data types `int` or `float`."
+    "New values can be obtained by applying operators to old values, for example, mathematical operators on numerical data types `int` or `float`:"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "bafdcfb2",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "- String: concatenation with `+`\n",
-    "- Bool: `and`, `or`, `not`\n",
     "- Numerical data: `+`, `-`, `*`, `/`, `%`, `**`, built-in functions `abs`, ...\n",
     "- Order of execution:\n",
     "    1. `()`\n",
@@ -1070,9 +1181,11 @@
    "cell_type": "markdown",
    "id": "07f5fa41",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1082,13 +1195,15 @@
    "cell_type": "markdown",
    "id": "56de4f19",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
-    "- These are the basic operations we have for our data types: String concatenation with the plus sign, logical operations on booleans with and, or, and not, and for floats and integers we have addition, subtraction, multiplication, division, modulo (i.e., the remainder of a division), exponentiation, absolute value, and so on.\n",
-    " - It is very important to be aware how these operations are executed in long arithmetic expressions. Generally, if you have something like a plus b plus c, it happens from left to right: First a plus b, and then plus c. However, if you have exponents, like a to the power of b to the power of c, the right-most operations happens first: b to the power of c, and then a to the power of the result. Exponents bind stronger than times and division, i.e. exponents are computed first, and times and division is stronger than plus and minus. If in doubt, just use parenthesis.\n",
+    "- These are the basic operations we have for our data types: String concatenation with the `+` sign, and for floats and integers we have addition, subtraction, multiplication, division, modulo (i.e. the remainder of a division), exponentiation, absolute value, and so on. Later on, when we talk about conditional statements, we'll introduce logical operations on booleans with `and`, `or`, and `not`.\n",
+    " - It is very important to be aware how these operations are executed in long arithmetic expressions. Generally, if you have something like `a+b+c`, it happens from left to right: First `a+b`, and then `+c`. However, if you have exponents, like `a` to the power of `b` to the power of `c`, the right-most operations happens first: `b` to the power of `c`, and then `a` to the power of the result. Exponents bind stronger than times and division, i.e. exponents are computed first, and times and division is stronger than plus and minus. If in doubt, just use parenthesis.\n",
     " - You will have the chance to play around with this in a moment, and find out for yourselves how it works."
    ]
   },
@@ -1096,9 +1211,11 @@
    "cell_type": "markdown",
    "id": "d1091173",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Comments (and documentation)\n",
@@ -1110,9 +1227,11 @@
    "execution_count": null,
    "id": "ab4e37e2",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1135,9 +1254,11 @@
    "cell_type": "markdown",
    "id": "3364ee6e",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1147,9 +1268,11 @@
    "cell_type": "markdown",
    "id": "1fbcaafc",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "But first, I want to show you two more things.\n",
@@ -1161,9 +1284,11 @@
    "cell_type": "markdown",
    "id": "3645d572",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Debugging and Types of Errors"
@@ -1173,9 +1298,11 @@
    "cell_type": "markdown",
    "id": "8afa6f79",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "<center>\n",
@@ -1195,9 +1322,11 @@
    "cell_type": "markdown",
    "id": "111e5796",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1207,9 +1336,11 @@
    "cell_type": "markdown",
    "id": "f6ab38be",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "- This is a moth which was discovered trapped within the Harvard Mark II computer in 1947, the first case of an actual computer bug! Although the term `bug` was already in use at this point.\n",
@@ -1220,9 +1351,11 @@
    "cell_type": "markdown",
    "id": "728407a5",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     " - Syntax errors are usually the easiest to spot. We have seen them before, when we wrote some code that was not valid, made a typo or so. Your interpreter or compiler will tell you straight away that something is wrong.\n",
@@ -1234,9 +1367,11 @@
    "cell_type": "markdown",
    "id": "1f4dfa6d",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -1245,7 +1380,13 @@
   {
    "cell_type": "markdown",
    "id": "6277b6c2",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
    "source": [
     "### _Exercises_"
    ]
@@ -1254,7 +1395,7 @@
    "cell_type": "markdown",
    "id": "264f4cf3",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -1274,9 +1415,11 @@
    "cell_type": "markdown",
    "id": "0c37d601",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1286,9 +1429,11 @@
    "cell_type": "markdown",
    "id": "9298bbd5",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Now it's time for you to try the things that we have learned about yourselves. I want you to think about data types, variables, the different operations, comments and errors, and find out more about how they work by experimenting. Write little bits of code and see what works, what doesn't, and how the output changes.\n",
@@ -1304,7 +1449,7 @@
    "cell_type": "markdown",
    "id": "bf4d52bb",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1319,7 +1464,6 @@
    "execution_count": null,
    "id": "1ee8a92f",
    "metadata": {
-    "editable": true,
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
@@ -1336,7 +1480,7 @@
    "cell_type": "markdown",
    "id": "4757c3c2",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1351,7 +1495,6 @@
    "execution_count": null,
    "id": "15006274",
    "metadata": {
-    "editable": true,
     "remove_code": "non-comments",
     "slideshow": {
      "slide_type": ""
@@ -1370,9 +1513,9 @@
    "cell_type": "markdown",
    "id": "2bcb76ab",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -1384,9 +1527,9 @@
    "cell_type": "markdown",
    "id": "6bf1c0b8",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "fragment"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -1398,7 +1541,7 @@
    "cell_type": "markdown",
    "id": "3060c201",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1433,7 +1576,7 @@
    "cell_type": "markdown",
    "id": "8ffe919b",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1471,7 +1614,7 @@
    "cell_type": "markdown",
    "id": "ca7a2bf1",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1486,7 +1629,7 @@
    "cell_type": "markdown",
    "id": "5280e49d",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -1517,7 +1660,7 @@
    "cell_type": "markdown",
    "id": "1786772f",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -1548,7 +1691,7 @@
    "cell_type": "markdown",
    "id": "5234c07e",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -1580,7 +1723,7 @@
    "cell_type": "markdown",
    "id": "2f3d5124",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1601,9 +1744,11 @@
    "cell_type": "markdown",
    "id": "99fb2c8b",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1613,9 +1758,11 @@
    "cell_type": "markdown",
    "id": "440a73c8",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "We will now encounter indented blocks. In contrast to a lot of other programming languages, code blocks in python are denoted by an indentation, not brackets."
@@ -1625,9 +1772,11 @@
    "cell_type": "markdown",
    "id": "c1b5c739",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>2.</ins> Functions"
@@ -1637,9 +1786,11 @@
    "cell_type": "markdown",
    "id": "3f6b80d9",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "A function is a block of reusable code that performs a specific task. Functions help reduce repetition and make code easier to manage. A function is defined using the `def` keyword."
@@ -1648,7 +1799,13 @@
   {
    "cell_type": "markdown",
    "id": "383ac2a1",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "* You can pass data to functions (parameters).\n",
     "* Functions can return values.\n",
@@ -1659,7 +1816,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2ab9f7d9",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Function to add two numbers\n",
@@ -1675,9 +1838,11 @@
    "cell_type": "markdown",
    "id": "2a8095f4",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -1687,7 +1852,7 @@
    "cell_type": "markdown",
    "id": "6bd208c9",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1727,7 +1892,7 @@
    "cell_type": "markdown",
    "id": "698e44f7",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -1741,9 +1906,11 @@
    "cell_type": "markdown",
    "id": "84db8e18",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>3.</ins> Getting Data in and out"
@@ -1753,15 +1920,43 @@
    "cell_type": "markdown",
    "id": "ab8c4b84",
    "metadata": {
+    "editable": true,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
-    "Now that we have covered the basics, let's move on to the next level. I expect that most of you are interested in processing data in one way or the other. Most times, we do not want to explicitly write our data into our code, which is also called \"hardcoding\", and has a bad reputation.\n",
+    "Now that we have covered the basics, let's move on to the next level. I expect that most of you are interested in processing data in one way or the other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d579678-303c-45c0-8ec1-2233f774b99a",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Most times, we do not want to explicitly write our data into our code, which is also called \"hardcoding\", and has a bad reputation.\n",
     "\n",
-    "Instead, we want to be able to provide data during runtime, and have a general program that is able to process the data.\n",
-    "\n",
+    "Instead, we want to be able to provide data during runtime, and have a general program that is able to process the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3bab333-2da3-40fc-94d6-4974b29305d0",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": []
+   },
+   "source": [
     "How then do we get the data in and out of our program?"
    ]
   },
@@ -1769,9 +1964,11 @@
    "cell_type": "markdown",
    "id": "9c90ef10",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## User input\n",
@@ -1821,9 +2018,11 @@
    "cell_type": "markdown",
    "id": "b613711d",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1833,9 +2032,11 @@
    "cell_type": "markdown",
    "id": "b88cb146",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "As an equivalent to the `print` built-in function, there is the `input` built-in function. It just takes the input from the command line or terminal, and you can do with it whatever you like. For example, here I am putting it into a variable `x`, and then output it. You can also add a prompting message to the user to tell them what kind of input you expect. Note that, just as `print` outputs a string, any user input will be interpreted as of type `str`, regardless of whether it is made out of letters, numbers, or symbols. So you might need to convert it to whatever data type you need it to be.\n",
@@ -1847,9 +2048,11 @@
    "cell_type": "markdown",
    "id": "81998d75",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Reading and writing files"
@@ -1859,9 +2062,11 @@
    "cell_type": "markdown",
    "id": "415ad1e8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "```python\n",
@@ -1882,9 +2087,11 @@
    "cell_type": "markdown",
    "id": "b7b9e65c",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1894,9 +2101,11 @@
    "cell_type": "markdown",
    "id": "79b9413a",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "The actual data input will usually happen over a file. Follow me in creating a new file.\n",
@@ -1912,9 +2121,11 @@
    "cell_type": "markdown",
    "id": "3f9c2877",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Writing files and formatting strings (C-style)"
@@ -1925,7 +2136,6 @@
    "execution_count": null,
    "id": "f45fde6e",
    "metadata": {
-    "editable": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -1945,9 +2155,11 @@
    "cell_type": "markdown",
    "id": "0d884b3f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "see also [https://www.learnpython.org/en/String\\_Formatting](https://www.learnpython.org/en/String_Formatting)"
@@ -1957,9 +2169,11 @@
    "cell_type": "markdown",
    "id": "a3e4908c",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -1969,9 +2183,11 @@
    "cell_type": "markdown",
    "id": "ab1c3573",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "Now we are writing some text and numbers into our file. Note that, again, everything needs to be a _string_. We can put in numbers either by converting them directly to a string, or by putting in a place holder, like this \"_percent d_\", for numerical or decimal values, and then putting in the number after the string. The \"_backslash n_\" symbol stands for a line break.\n",
@@ -1983,9 +2199,11 @@
    "cell_type": "markdown",
    "id": "16c995a4",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Writing files (f-strings)"
@@ -2016,9 +2234,11 @@
    "cell_type": "markdown",
    "id": "4db7b7e2",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "see also [f-strings](https://realpython.com/python-f-strings/)"
@@ -2028,9 +2248,11 @@
    "cell_type": "markdown",
    "id": "8df0fc34",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -2040,9 +2262,11 @@
    "cell_type": "markdown",
    "id": "06d46466",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "This similar as on the previous slide. We open the same file in _append_-mode and add some more lines, using _f-strings_ instead of _C-style_ string formatting for including numbers.\n",
@@ -2058,9 +2282,11 @@
    "cell_type": "markdown",
    "id": "a7533130",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Reading files"
@@ -2093,9 +2319,11 @@
    "cell_type": "markdown",
    "id": "ced6875f",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "##### _<ins>Notes:</ins>_"
@@ -2105,9 +2333,11 @@
    "cell_type": "markdown",
    "id": "b13346bf",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "In the next step, we will read out data from the file that we have just created. There are different ways of doing this. In this example, I combine the reading directly with a `print` statement, so that I see the result. Usually you would probably put the output of the reading operation into a `variable` and continue to process it.\n",
@@ -2123,9 +2353,11 @@
    "cell_type": "markdown",
    "id": "a94ee2ee",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Have a play!"
@@ -2134,7 +2366,13 @@
   {
    "cell_type": "markdown",
    "id": "667c37bc",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
    "source": [
     "### _Exercises_"
    ]
@@ -2143,9 +2381,11 @@
    "cell_type": "markdown",
    "id": "be0762cb",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": ""
-    }
+    },
+    "tags": []
    },
    "source": [
     "Here are some exercise ideas for \"Getting data in and out\":\n",
@@ -2172,9 +2412,11 @@
    "cell_type": "markdown",
    "id": "372a5ff1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# <ins>4.</ins> Data structures"
@@ -2183,7 +2425,13 @@
   {
    "cell_type": "markdown",
    "id": "1dda0b37",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "Python can work not only with basic data types mentioned before, but also with compound ones. Compound data types in Python are a powerful tool for organizing and storing data. Among the most commonly used are _lists_ and _dictionaries_. `For`-loops described in the next section often iterate over elements of lists or pairs of keys and values in dictionaries. But they can also iterate over a series of numbers generated for indexing or calculations by the `range()` function."
    ]
@@ -2192,9 +2440,11 @@
    "cell_type": "markdown",
    "id": "bf322501",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Lists"
@@ -2203,7 +2453,13 @@
   {
    "cell_type": "markdown",
    "id": "4eea3782",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "_Lists_ are ordered collections of items."
    ]
@@ -2212,7 +2468,7 @@
    "cell_type": "markdown",
    "id": "99ce3685",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2229,7 +2485,7 @@
    "cell_type": "markdown",
    "id": "a7d14dc3",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2425,9 +2681,9 @@
    "cell_type": "markdown",
    "id": "ea0a97df",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2439,9 +2695,11 @@
    "cell_type": "markdown",
    "id": "cbc0427a",
    "metadata": {
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
-    }
+     "slide_type": "skip"
+    },
+    "tags": []
    },
    "source": [
     "This kind of structure is called a _list_, and it is an essential data structure in Python programming.\n",
@@ -2454,9 +2712,9 @@
    "cell_type": "markdown",
    "id": "abf28fb3",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2468,9 +2726,9 @@
    "cell_type": "markdown",
    "id": "2f6b1207",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2486,9 +2744,11 @@
    "cell_type": "markdown",
    "id": "80bb51c1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## _Range()_ function"
@@ -2497,7 +2757,13 @@
   {
    "cell_type": "markdown",
    "id": "11ddd405",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "The `range()` function in Python is used to generate a sequence of numbers. It takes up to three arguments: `start`, `stop`, and `step`. By default, `start` is 0, `step` is 1, and the sequence ends just before the `stop` value."
    ]
@@ -2505,7 +2771,13 @@
   {
    "cell_type": "markdown",
    "id": "2a95ec20",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "* `range(stop)`: Generates numbers from 0 to stop - 1.\n",
     "* `range(start, stop)`: Generates numbers from start to stop - 1.\n",
@@ -2518,9 +2790,11 @@
    "cell_type": "markdown",
    "id": "f85dc66b",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -2530,7 +2804,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "15c025b6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "range(10)"
@@ -2540,7 +2820,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f82ab219",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(10))"
@@ -2550,7 +2836,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0b6a1718",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(1,10))"
@@ -2560,7 +2852,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51dbf5d6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(3,7))"
@@ -2570,7 +2868,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2711d0ef",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(2,15,3))"
@@ -2580,7 +2884,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1564575c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "list(range(9,2,-1))"
@@ -2590,9 +2900,11 @@
    "cell_type": "markdown",
    "id": "9d8538d8",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Have a Play!"
@@ -2601,7 +2913,13 @@
   {
    "cell_type": "markdown",
    "id": "bf596194",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
    "source": [
     "### _Exercises_"
    ]
@@ -2610,7 +2928,7 @@
    "cell_type": "markdown",
    "id": "82edf40e",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2642,7 +2960,7 @@
    "cell_type": "markdown",
    "id": "958677ed",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2674,7 +2992,7 @@
    "cell_type": "markdown",
    "id": "5efb8831",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -2688,9 +3006,9 @@
    "cell_type": "markdown",
    "id": "b70dd974-edaf-4754-9584-93f50921e743",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -2715,9 +3033,9 @@
    "cell_type": "markdown",
    "id": "32e96a87-2d10-4fde-9d13-c3e805753b12",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2729,9 +3047,9 @@
    "cell_type": "markdown",
    "id": "da74c8ad-9e71-41b2-8dd0-8e3ec967678b",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2743,21 +3061,21 @@
    "cell_type": "markdown",
    "id": "74af5f47-ab75-4df1-91b8-3190bedc2ca6",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "### _<ins>Examples:</ins>_ Comparisons"
+    "### Comparisons"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e2cceb3d-3087-4a36-97de-e2e812c591e4",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2795,7 +3113,7 @@
    "cell_type": "markdown",
    "id": "c907d157-f6a7-4b69-8f6e-93c1ff5fc94e",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2830,7 +3148,13 @@
   {
    "cell_type": "markdown",
    "id": "9fed5023-5d86-4427-96b0-555924659ed1",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": []
+   },
    "source": [
     "##### _<ins>Notes:</ins>_"
    ]
@@ -2839,9 +3163,9 @@
    "cell_type": "markdown",
    "id": "6452908a-8d20-43c3-a515-8a524a526d9d",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2853,21 +3177,21 @@
    "cell_type": "markdown",
    "id": "396617ca",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
     "tags": []
    },
    "source": [
-    "### _<ins>Examples</ins>:_ Logical operators"
+    "### Logical operators"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "89b36ecb-cdca-403c-956a-fb3a76fd020d",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -2984,9 +3308,9 @@
    "cell_type": "markdown",
    "id": "d4c72581",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -2998,10 +3322,10 @@
    "cell_type": "markdown",
    "id": "58c185a7",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
-     "slide_type": "notes"
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -3013,10 +3337,10 @@
    "cell_type": "markdown",
    "id": "a6e41b34-6325-41d8-ac88-d12f6a4a0b4f",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -3034,9 +3358,9 @@
    "cell_type": "markdown",
    "id": "b3a50a84-306d-45dd-a1f4-28fe86b67360",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },
@@ -3069,11 +3393,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fabcdd8-baea-43bd-b61e-7af35de49381",
+   "id": "07f4944d-215c-470c-b425-36424b3c39a7",
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "skip"
+    },
+    "tags": []
+   },
+   "source": [
+    "##### _<ins>Notes:</ins>_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fabcdd8-baea-43bd-b61e-7af35de49381",
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": "skip"
     },
     "tags": []
    },
@@ -3085,7 +3423,7 @@
    "cell_type": "markdown",
    "id": "24d65380",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -3099,7 +3437,7 @@
    "cell_type": "markdown",
    "id": "86caca1c",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": ""
     },
@@ -3117,9 +3455,11 @@
    "cell_type": "markdown",
    "id": "0b373d79",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "source": [
     "Examples of conditional operators (expressions and their descriptions):\n",
@@ -3140,9 +3480,11 @@
    "cell_type": "markdown",
    "id": "077114b1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -3170,7 +3512,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ffc89ad1",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "grade = int(input('Enter your score: '))"
@@ -3232,9 +3580,11 @@
    "cell_type": "markdown",
    "id": "24654b8b",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## _For_-loops"
@@ -3243,7 +3593,13 @@
   {
    "cell_type": "markdown",
    "id": "634a4e09",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "A `for`-loop iterates over a sequence (like a list, string, or range) and executes a block of code for each item in that sequence."
    ]
@@ -3251,7 +3607,13 @@
   {
    "cell_type": "markdown",
    "id": "7be926fd",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "* A `for`-loop is a _control_ instruction used for iteration and repetition\n",
     "* **iteration** .. perform _same operation_ on _different items_, one item at a time\n",
@@ -3266,9 +3628,11 @@
    "cell_type": "markdown",
    "id": "82b16990",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -3278,7 +3642,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e64c509",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Iterating over a list\n",
@@ -3321,9 +3691,11 @@
    "cell_type": "markdown",
    "id": "fc875a1f",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## _While_-loops"
@@ -3332,7 +3704,13 @@
   {
    "cell_type": "markdown",
    "id": "96ad7d45",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "A `while`-loop keeps executing a block of code as long as its condition remains true. It's commonly used for indefinite loops where the number of iterations isn’t known beforehand."
    ]
@@ -3340,7 +3718,13 @@
   {
    "cell_type": "markdown",
    "id": "f8ace486",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "* A `while`-loop is a _control_ instruction ideal for _indefinite loops_ when we don’t know when it ends\n",
     "* Keywords: `while`\n",
@@ -3354,9 +3738,11 @@
    "cell_type": "markdown",
    "id": "e8b309d0",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### _<ins>Examples:</ins>_"
@@ -3409,9 +3795,11 @@
    "cell_type": "markdown",
    "id": "d27544ee",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "## Have a Play!"
@@ -3421,7 +3809,7 @@
    "cell_type": "markdown",
    "id": "7a2f1f84",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -3435,9 +3823,9 @@
    "cell_type": "markdown",
    "id": "c60fe3a1",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -3472,9 +3860,9 @@
    "cell_type": "markdown",
    "id": "1cfae422",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -3504,9 +3892,9 @@
    "cell_type": "markdown",
    "id": "87c1529d",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -3539,9 +3927,9 @@
    "cell_type": "markdown",
    "id": "db69b6c7",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": ""
     },
     "tags": []
    },
@@ -3577,7 +3965,7 @@
    "cell_type": "markdown",
    "id": "fb1b118c",
    "metadata": {
-    "editable": true,
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
     },
@@ -3590,7 +3978,13 @@
   {
    "cell_type": "markdown",
    "id": "d029a1c0",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "To run python outside of the JupyterLite environment you need to install it locally. As with a lot of large programming languages there are multiple solutions to do this. The two common families of solutions are python with pip and conda/mamba."
    ]
@@ -3598,7 +3992,13 @@
   {
    "cell_type": "markdown",
    "id": "e8556ab8",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "| Feature | **Python with pip** | **Conda/Mamba** |\n",
     "|---------|----------------|-----------------|\n",
@@ -3619,9 +4019,11 @@
    "cell_type": "markdown",
    "id": "9bf355f1",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Installing Python and pip"
@@ -3630,7 +4032,13 @@
   {
    "cell_type": "markdown",
    "id": "d0b30d43",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On Windows:"
    ]
@@ -3638,7 +4046,13 @@
   {
    "cell_type": "markdown",
    "id": "e0a9656c",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Go to https://www.python.org/downloads/) and choose the latest stable installer for Windows (for example, “Windows installer (64-bit)”).\n",
     "2. During installation, make sure to check the box “Add Python to PATH” so you can use Python from any command prompt.\n",
@@ -3656,7 +4070,13 @@
   {
    "cell_type": "markdown",
    "id": "b03e4874",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On Linux (Ubuntu/Debian-based):"
    ]
@@ -3664,7 +4084,13 @@
   {
    "cell_type": "markdown",
    "id": "546d664c",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Open a terminal.\n",
     "2. Run:\n",
@@ -3686,7 +4112,13 @@
   {
    "cell_type": "markdown",
    "id": "d25e9eaa",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On macOS:"
    ]
@@ -3694,7 +4126,13 @@
   {
    "cell_type": "markdown",
    "id": "32384276",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Visit https://www.python.org/downloads/ and download the macOS installer (e.g., “macOS 64-bit universal2 installer”).\n",
     "2. Double-click the `.pkg` file and follow the prompts.\n",
@@ -3713,9 +4151,11 @@
    "cell_type": "markdown",
    "id": "6ad36f9c",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Installing and Running Jupyter Notebooks"
@@ -3724,7 +4164,13 @@
   {
    "cell_type": "markdown",
    "id": "88323ba7",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Once Python is installed (whether from python.org, your Linux package manager, or Anaconda), you can install Jupyter Lab as follows:\n",
     "```\n",
@@ -3748,9 +4194,11 @@
    "cell_type": "markdown",
    "id": "1ea7de96",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Installing Mamba (via Miniforge)"
@@ -3759,7 +4207,13 @@
   {
    "cell_type": "markdown",
    "id": "88f8fa02",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On Windows:"
    ]
@@ -3767,7 +4221,13 @@
   {
    "cell_type": "markdown",
    "id": "bc5d5add",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Go to https://github.com/conda-forge/miniforge and download the Miniforge3 installer for Windows (e.g., \"Miniforge3-Windows-x86_64.exe\").\n",
     "2. Run the installer and follow the prompts. You can accept the default options.\n",
@@ -3786,7 +4246,13 @@
   {
    "cell_type": "markdown",
    "id": "a9daafa9",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On Linux (Ubuntu/Debian-based and others):"
    ]
@@ -3794,7 +4260,13 @@
   {
    "cell_type": "markdown",
    "id": "ba271553",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Open a terminal and download the installer:\n",
     "```bash\n",
@@ -3825,7 +4297,13 @@
   {
    "cell_type": "markdown",
    "id": "f2e714e4",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "#### On macOS:"
    ]
@@ -3833,7 +4311,13 @@
   {
    "cell_type": "markdown",
    "id": "232aee40",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Download the installer from https://github.com/conda-forge/miniforge:\n",
     "   - For Intel Macs: `Miniforge3-MacOSX-x86_64.sh`\n",
@@ -3868,9 +4352,11 @@
    "cell_type": "markdown",
    "id": "68d32a65",
    "metadata": {
+    "editable": false,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "### Installing and Running Jupyter Notebooks with Mamba"
@@ -3879,7 +4365,13 @@
   {
    "cell_type": "markdown",
    "id": "38068a3a",
-   "metadata": {},
+   "metadata": {
+    "editable": false,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "1. Once Miniforge/Mamba is installed, you can install JupyterLab in a new environment for your project:\n",
     "```bash\n",
@@ -3902,7 +4394,13 @@
   {
    "cell_type": "markdown",
    "id": "ac3d4b98",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": []
   }
  ],


### PR DESCRIPTION
Added "Comparisons and Logical Operators" subsection before "If"-statements and move all relevant content there
- **Remove** abstract boolean operations from basic types section
- **Create** new "Comparisons and Logical Operators" subsection before "If-statements
- **Restructure** logical operations to follow comparisons
- **Create** bridge content connecting operators to control flow
- **Reference** operators explicitly in the `if`-statements introduction

Also removed the outdated `#solution`-`#endsolution` comment sections used in old versions to remove solutions from filled notebooks (now, Jupyter cell metada are utilised instead).